### PR TITLE
Added useful exception if Mozilla can't be located

### DIFF
--- a/sniper/webdriver.py
+++ b/sniper/webdriver.py
@@ -17,6 +17,8 @@ def get_default_profile():
             'Library' / 'Application Support' / 'Firefox'
     elif platform == 'win32':
         mozilla_profile = Path(os.getenv('APPDATA')) / 'Mozilla' / 'Firefox'
+    if not mozilla_profile.exists():
+        raise Exception("Mozilla profile doesn't exist and/or can't be located on this machine.")
 
     mozilla_profile_ini = mozilla_profile / 'profiles.ini'
     profile = configparser.ConfigParser()

--- a/sniper/webdriver.py
+++ b/sniper/webdriver.py
@@ -18,7 +18,7 @@ def get_default_profile():
     elif platform == 'win32':
         mozilla_profile = Path(os.getenv('APPDATA')) / 'Mozilla' / 'Firefox'
     if not mozilla_profile.exists():
-        raise Exception("Mozilla profile doesn't exist and/or can't be located on this machine.")
+        raise FileNotFoundError("Mozilla profile doesn't exist and/or can't be located on this machine.")
 
     mozilla_profile_ini = mozilla_profile / 'profiles.ini'
     profile = configparser.ConfigParser()


### PR DESCRIPTION
This PR adds just two lines of codes to improve the user's experience if they don't have Mozilla Firefox installed on their local machine.