### PR TITLE
Retry navigating to checkout

### DIFF
--- a/sniper/__main__.py
+++ b/sniper/__main__.py
@@ -78,8 +78,9 @@ async def checkout_api(driver, user_agent, timeout, locale, dr_locale, api_curre
                     logging.exception(f'Failed to add item to basket')
                     return False
                 try:
-                    logging.info('Going to checkout page...')
-                    driver.get(const.CHECKOUT_URL)
+                    while const.CHECKOUT_MATCH not in driver.current_url
+                        logging.info(f'Navigating to checkout page {const.CHECKOUT_URL}. Current page {driver.current_url}')
+                        driver.get(const.CHECKOUT_URL)
                     if notifications['add-to-basket']['enabled']:
                         driver.save_screenshot(const.SCREENSHOT_FILE)
                         notification_queue.put('add-to-basket')

--- a/sniper/constants.py
+++ b/sniper/constants.py
@@ -40,3 +40,5 @@ CHECKOUT_URL = f'{STORE_URL}?Action=DisplayHGOP2LandingPage&SiteID=nvidia'
 API_HOST = 'api-prod.nvidia.com'
 INVENTORY_URL = f'https://{API_HOST}/direct-sales-shop/DR/products'
 ADD_TO_CART_URL = f'https://{API_HOST}/direct-sales-shop/DR/add-to-cart'
+
+CHECKOUT_MATCH = 'id=QuickBuyCartPage'


### PR DESCRIPTION
I got a "Game Over This Page Is Toast" page during the drop today during checkout navigation which broke the bot. https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/rtx-3080/undefined/

This will retry going to the checkout page until successful.