### PR TITLE
Prevent crash if users forget to update their customer.json with back…

### DIFF
--- a/sniper/nvidia.py
+++ b/sniper/nvidia.py
@@ -137,11 +137,17 @@ def fill_out_form(driver, timeout, customer):
             driver.find_element(By.ID, shipping_speed).click()
         except Exception:
             logging.warning(f'Could not find shipping speed {shipping_speed}')
-            if customer['shipping']['backup-speed']:
-                logging.info('Continuing with default speed')
+            if 'backup-speed' in customer['shipping']:
+                if customer['shipping']['backup-speed']:
+                    logging.info('Continuing with default speed')
+                else:
+                    logging.info('User opted to stop if shipping speed not found.')
+                    exit()
             else:
-                logging.info('User opted to stop if shipping speed not found.')
-                exit()
+                logging.warning(
+                    'data/customer.json missing "backup-speed" option under "shipping", '\
+                    'continuing with default speed')
+                   
 
         shipping_expanded = False
         while not shipping_expanded:


### PR DESCRIPTION
…up-speed property

So while reading messages on discord this morning about people seeing PR #46 and asking about it, I realized that there could be an issue if users do not realize they need to add the new backup-speed property to their customer.json file, so I'm adding a check for that so the bot doesn't crash if the property is missing.