### PR TITLE
Add mechanism to retry if API times out

### DIFF
--- a/sniper/api.py
+++ b/sniper/api.py
@@ -1,23 +1,78 @@
+import asyncio
+import logging
 import sniper.constants as const
 
+# TODO: Review if json is correct to be set as None, should not matter but just in case
+async def http_post(session, url, timeout=60, headers=None, json=None, attempt=0, retries=3, retry=True):
+    try:
+        async with session.post(url, timeout=timeout, headers=headers, json=json) as response:
+            if response.status == 200:
+                return response
+            else:
+                raise(SystemError(await response.text()))
+    except asyncio.TimeoutError as error:
+        if (attempt < retries and retry) or (retries == 0 and retry):
+            next_attempt = attempt + 1
+
+            logging.info(f'Request to {url} failed, trying again')
+
+            return await http_post(
+                session=session, 
+                url=url, 
+                timeout=timeout, 
+                headers=headers,
+                json=json,
+                attempt=next_attempt, 
+                retries=retries, 
+                retry=True
+            )
+        else:
+            raise(error)
+
+async def http_get(session, url, timeout=60, headers=None, attempt=0, retries=3, retry=True):
+    try:
+        async with session.get(url, timeout=timeout, headers=headers) as response:
+            if response.status == 200:
+                return await response.json()
+            else:
+                raise(SystemError(await response.text()))
+    except asyncio.TimeoutError as error:
+        if (attempt < retries and retry) or (retries == 0 and retry):
+            next_attempt = attempt + 1
+
+            logging.info(f'Request to {url} failed, trying again')
+
+            return await http_get(
+                session=session, 
+                url=url, 
+                timeout=timeout, 
+                headers=headers, 
+                attempt=next_attempt, 
+                retries=retries, 
+                retry=True
+            )
+        else:
+            raise(error)
 
 async def fetch_token(session, dr_locale):
-    async with session.get(f'{const.TOKEN_URL}?locale={dr_locale}') as response:
-        json_resp = await response.json()
-        return json_resp['session_token']
+    response = await http_get(f'{const.TOKEN_URL}?locale={dr_locale}')
+    
+    return response['session_token']
 
 
 async def add_to_cart(session, store_token, dr_locale, dr_id):
-    async with session.post(const.ADD_TO_CART_URL,
-                            headers={'nvidia_shop_id': store_token},
-                            json={"products": [{"productId": dr_id, "quantity": 1}]}) as response:
-        if response.status == 200:
-            return await response.json()
-        else:
-            raise(SystemError(await response.text()))
+    response = await http_post(
+        session=session, 
+        url=const.ADD_TO_CART_URL,
+        timeout=5,
+        headers={'nvidia_shop_id': store_token},
+        json={"products": [{"productId": dr_id, "quantity": 1}]}
+    )
+
+    return response
 
 
 async def get_inventory_status(session, dr_locale, api_currency, dr_id):
-    async with session.get(f'{const.INVENTORY_URL}/{dr_locale}/{api_currency}/{dr_id}') as response:
-        json_resp = await response.json()
-        return json_resp['products']['product'][0]['inventoryStatus']['status']
+    response = await http_get(session=session, url=f'{const.INVENTORY_URL}/{dr_locale}/{api_currency}/{dr_id}', timeout=10)
+    
+    return response['products']['product'][0]['inventoryStatus']['status']


### PR DESCRIPTION
Added utilities to do http requests and perform retries when the API takes long to respond.

**Features**

- Performs retry on add to cart if 5 secs already passed by
- Performs retry on get stock if 10 secs already passed by

**Caveats**

- If the API responds with timeout before aiohttp throws timeout error itself it will be handled as an error and do not perform a retry. Can be avoided if the response status 504 is handled too.
- After some quick testing, seems that the average time in order for aiohttp to throw is about 10-15 secs, more than that and the API will throw and not aiohttp