### PR TITLE
Enables user to skip "auto-submit" option select if choosing Paypal

### DIFF
--- a/sniper/__main__.py
+++ b/sniper/__main__.py
@@ -193,10 +193,14 @@ async def main():
                              'Which payment method do you want to use?',
                              indicator='=>')
 
-    auto_submit, _ = pick(['Yes', 'No'],
-                          'Do you want to automatically submit the order? (only works with credit card)',
-                          indicator='=>',  default_index=1)
-    auto_submit = auto_submit == 'Yes'
+    auto_submit = None
+    if payment_method == 'credit-card':
+        auto_submit, _ = pick(['Yes', 'No'],
+                              'Do you want to automatically submit the order? (only works with credit card)',
+                              indicator='=>',  default_index=1)
+        auto_submit = auto_submit == 'Yes'
+    else:
+        auto_submit = False
 
     timeout, _ = pick([' 4 seconds', ' 8 seconds', '16 seconds', '32 seconds', '64 seconds'],
                       'Please choose a timout / refresh interval', indicator='=>', default_index=1)

--- a/sniper/__main__.py
+++ b/sniper/__main__.py
@@ -196,7 +196,7 @@ async def main():
     auto_submit = None
     if payment_method == 'credit-card':
         auto_submit, _ = pick(['Yes', 'No'],
-                              'Do you want to automatically submit the order? (only works with credit card)',
+                              'Do you want to automatically submit the order?',
                               indicator='=>',  default_index=1)
         auto_submit = auto_submit == 'Yes'
 

--- a/sniper/__main__.py
+++ b/sniper/__main__.py
@@ -199,8 +199,6 @@ async def main():
                               'Do you want to automatically submit the order? (only works with credit card)',
                               indicator='=>',  default_index=1)
         auto_submit = auto_submit == 'Yes'
-    else:
-        auto_submit = False
 
     timeout, _ = pick([' 4 seconds', ' 8 seconds', '16 seconds', '32 seconds', '64 seconds'],
                       'Please choose a timout / refresh interval', indicator='=>', default_index=1)


### PR DESCRIPTION
I don't know if auto checkout will come back for Paypal, but, for the time being, I thought it'd be nice if users can skip this part if choosing Paypal as payment option. I was personally a little confused when prompted with "only works with credit card" when choosing Paypal.