### PR TITLE
Removed typo in "customers.json"

### DIFF
--- a/sniper/__main__.py
+++ b/sniper/__main__.py
@@ -63,7 +63,7 @@ def read_config():
         customer = read_json(config_path / 'customer.json')
     except FileNotFoundError:
         logger.critical(
-            'Missing customer configuration file, copy the template to config/customers.json and customize as described in the README to continue.')
+            'Missing customer configuration file, copy the template to config/customer.json and customize as described in the README to continue.')
         sys.exit()
     except json.decoder.JSONDecodeError:
         logger.critical(


### PR DESCRIPTION
Help output text from __main__.py tells users to copy the customer template to customers.json, but the program actually looks for customer.json, so I removed the s in the call to logger.critical()